### PR TITLE
250326_22_최지민

### DIFF
--- a/lib/dart_debug_sample.dart
+++ b/lib/dart_debug_sample.dart
@@ -44,24 +44,28 @@ class YukymController {
     final nowTime = DateTime.now();
     if (nowTime.hour >= 0 || nowTime.hour < 2) {
       return timeDataOne.first.ty1;
-    } else if (nowTime.hour >= 4 || nowTime.hour < 6) {
+    } else if (nowTime.hour >= 2 || nowTime.hour < 4) { // 2 ~ 4 빠짐
       return timeDataOne.first.ty2;
-    } else if (nowTime.hour >= 6 || nowTime.hour < 8) {
+    } else if (nowTime.hour >= 4 || nowTime.hour < 6) {
       return timeDataOne.first.ty3;
-    } else if (nowTime.hour >= 8 || nowTime.hour < 10) {
+    } else if (nowTime.hour >= 6 || nowTime.hour < 8) {
       return timeDataOne.first.ty4;
-    } else if (nowTime.hour >= 10 || nowTime.hour < 12) {
+    } else if (nowTime.hour >= 8 || nowTime.hour < 10) {
       return timeDataOne.first.ty5;
-    } else if (nowTime.hour >= 12 || nowTime.hour < 14) {
+    } else if (nowTime.hour >= 10 || nowTime.hour < 12) {
       return timeDataOne.first.ty6;
-    } else if (nowTime.hour >= 16 || nowTime.hour < 18) {
+    } else if (nowTime.hour >= 12 || nowTime.hour < 14) {
       return timeDataOne.first.ty7;
-    } else if (nowTime.hour >= 18 || nowTime.hour < 20) {
+    } else if (nowTime.hour >= 14 || nowTime.hour < 16){ // 14 ~ 16 빠짐
       return timeDataOne.first.ty8;
-    } else if (nowTime.hour >= 20 || nowTime.hour < 22) {
+    } else if (nowTime.hour >= 16 || nowTime.hour < 18) {
       return timeDataOne.first.ty9;
-    } else if (nowTime.hour >= 22 || nowTime.hour < 24) {
+    } else if (nowTime.hour >= 18 || nowTime.hour < 20) {
       return timeDataOne.first.ty10;
+    } else if (nowTime.hour >= 20 || nowTime.hour < 22) {
+      return timeDataOne.first.ty11;
+    } else if (nowTime.hour >= 22 || nowTime.hour < 24) {
+      return timeDataOne.first.ty12;
     }
 
     return result;

--- a/lib/dart_debug_sample.dart
+++ b/lib/dart_debug_sample.dart
@@ -3,17 +3,17 @@ import 'package:intl/intl.dart';
 class YukymController {
 
   // DateTime.parse(_userData.value!.selectDate)
-  String nowDate = DateFormat('yyyy-mm-dd').format(DateTime.now());
+  // mm과 MM을 착각함. 수정
+  String nowDate = DateFormat('yyyy-MM-dd').format(DateTime.now());
 
   late String nowTime;
 
   // 1. 자시의 국 : 갑자1국 = getTyOne()의 값
   String getTyA() {
-    List<YukymTimeModel> timeDataOne =
-    _getTimeDataOne(nowDate);
+    List<YukymTimeModel> timeDataOne = _getTimeDataOne(nowDate);
 
     if (timeDataOne.isNotEmpty) {
-      nowTime = timeDataOne.first.ty1;
+      // nowTime = timeDataOne.first.ty1; <====== 존재이유 모를 코드
 
       final month = nowDate.substring(5, 7);
       if (month == '01' || month == '02') {
@@ -29,7 +29,7 @@ class YukymController {
       } else if (month == '11' || month == '12') {
         return '경오6국';
       }
-      return nowTime;
+      return '경오7국'; // 경오 7국
     } else {
       // Handle the case when the list is empty
       return '경오7국';  // Or any other appropriate action
@@ -42,29 +42,29 @@ class YukymController {
     String result = timeDataOne.first.ty12;
 
     final nowTime = DateTime.now();
-    if (nowTime.hour >= 0 || nowTime.hour < 2) {
+    if (nowTime.hour >= 0 && nowTime.hour < 2) {
       return timeDataOne.first.ty1;
-    } else if (nowTime.hour >= 2 || nowTime.hour < 4) { // 2 ~ 4 빠짐
+    } else if (nowTime.hour >= 2 && nowTime.hour < 4) { // 2 ~ 4 빠짐
       return timeDataOne.first.ty2;
-    } else if (nowTime.hour >= 4 || nowTime.hour < 6) {
+    } else if (nowTime.hour >= 4 && nowTime.hour < 6) {
       return timeDataOne.first.ty3;
-    } else if (nowTime.hour >= 6 || nowTime.hour < 8) {
+    } else if (nowTime.hour >= 6 && nowTime.hour < 8) {
       return timeDataOne.first.ty4;
-    } else if (nowTime.hour >= 8 || nowTime.hour < 10) {
+    } else if (nowTime.hour >= 8 && nowTime.hour < 10) {
       return timeDataOne.first.ty5;
-    } else if (nowTime.hour >= 10 || nowTime.hour < 12) {
+    } else if (nowTime.hour >= 10 && nowTime.hour < 12) {
       return timeDataOne.first.ty6;
-    } else if (nowTime.hour >= 12 || nowTime.hour < 14) {
+    } else if (nowTime.hour >= 12 && nowTime.hour < 14) {
       return timeDataOne.first.ty7;
-    } else if (nowTime.hour >= 14 || nowTime.hour < 16){ // 14 ~ 16 빠짐
+    } else if (nowTime.hour >= 14 && nowTime.hour < 16){ // 14 ~ 16 빠짐
       return timeDataOne.first.ty8;
-    } else if (nowTime.hour >= 16 || nowTime.hour < 18) {
+    } else if (nowTime.hour >= 16 && nowTime.hour < 18) {
       return timeDataOne.first.ty9;
-    } else if (nowTime.hour >= 18 || nowTime.hour < 20) {
+    } else if (nowTime.hour >= 18 && nowTime.hour < 20) {
       return timeDataOne.first.ty10;
-    } else if (nowTime.hour >= 20 || nowTime.hour < 22) {
+    } else if (nowTime.hour >= 20 && nowTime.hour < 22) {
       return timeDataOne.first.ty11;
-    } else if (nowTime.hour >= 22 || nowTime.hour < 24) {
+    } else if (nowTime.hour >= 22 && nowTime.hour < 24) {
       return timeDataOne.first.ty12;
     }
 

--- a/lib/dart_debug_sample.dart
+++ b/lib/dart_debug_sample.dart
@@ -9,66 +9,65 @@ class YukymController {
   late String nowTime;
 
   // 1. 자시의 국 : 갑자1국 = getTyOne()의 값
+  // 사용하지 않는 timeDataOne empty 체크 제거
   String getTyA() {
-    List<YukymTimeModel> timeDataOne = _getTimeDataOne(nowDate);
 
-    if (timeDataOne.isNotEmpty) {
-      // nowTime = timeDataOne.first.ty1; <====== 존재이유 모를 코드
-
-      final month = nowDate.substring(5, 7);
-      if (month == '01' || month == '02') {
-        return '경오1국';
-      } else if (month == '03' || month == '04') {
-        return '경오2국';
-      } else if (month == '05' || month == '06') {
-        return '경오3국';
-      } else if (month == '07' || month == '08') {
-        return '경오4국';
-      } else if (month == '09' || month == '10') {
-        return '경오5국';
-      } else if (month == '11' || month == '12') {
-        return '경오6국';
-      }
-      return '경오7국'; // 경오 7국
-    } else {
-      // Handle the case when the list is empty
-      return '경오7국';  // Or any other appropriate action
+    final month = nowDate.substring(5, 7);
+    if (month == '01' || month == '02') {
+      return '경오1국';
+    } else if (month == '03' || month == '04') {
+      return '경오2국';
+    } else if (month == '05' || month == '06') {
+      return '경오3국';
+    } else if (month == '07' || month == '08') {
+      return '경오4국';
+    } else if (month == '09' || month == '10') {
+      return '경오5국';
+    } else if (month == '11' || month == '12') {
+      return '경오6국';
     }
+    return '경오7국'; // 경오 7국
   }
 
+  // || => && 수정
+  // timeDataOne empty 체크 추가
   String getTyB() {
     List<YukymTimeModel> timeDataOne =
     _getTimeDataOne(nowDate);
-    String result = timeDataOne.first.ty12;
 
-    final nowTime = DateTime.now();
-    if (nowTime.hour >= 0 && nowTime.hour < 2) {
-      return timeDataOne.first.ty1;
-    } else if (nowTime.hour >= 2 && nowTime.hour < 4) { // 2 ~ 4 빠짐
-      return timeDataOne.first.ty2;
-    } else if (nowTime.hour >= 4 && nowTime.hour < 6) {
-      return timeDataOne.first.ty3;
-    } else if (nowTime.hour >= 6 && nowTime.hour < 8) {
-      return timeDataOne.first.ty4;
-    } else if (nowTime.hour >= 8 && nowTime.hour < 10) {
-      return timeDataOne.first.ty5;
-    } else if (nowTime.hour >= 10 && nowTime.hour < 12) {
-      return timeDataOne.first.ty6;
-    } else if (nowTime.hour >= 12 && nowTime.hour < 14) {
-      return timeDataOne.first.ty7;
-    } else if (nowTime.hour >= 14 && nowTime.hour < 16){ // 14 ~ 16 빠짐
-      return timeDataOne.first.ty8;
-    } else if (nowTime.hour >= 16 && nowTime.hour < 18) {
-      return timeDataOne.first.ty9;
-    } else if (nowTime.hour >= 18 && nowTime.hour < 20) {
-      return timeDataOne.first.ty10;
-    } else if (nowTime.hour >= 20 && nowTime.hour < 22) {
-      return timeDataOne.first.ty11;
-    } else if (nowTime.hour >= 22 && nowTime.hour < 24) {
-      return timeDataOne.first.ty12;
+    if (timeDataOne.isNotEmpty) {
+      String result = timeDataOne.first.ty12;
+
+      final nowTime = DateTime.now();
+      if (nowTime.hour >= 0 && nowTime.hour < 2) {
+        return timeDataOne.first.ty1;
+      } else if (nowTime.hour >= 2 && nowTime.hour < 4) { // 2 ~ 4 추가
+        return timeDataOne.first.ty2;
+      } else if (nowTime.hour >= 4 && nowTime.hour < 6) {
+        return timeDataOne.first.ty3;
+      } else if (nowTime.hour >= 6 && nowTime.hour < 8) {
+        return timeDataOne.first.ty4;
+      } else if (nowTime.hour >= 8 && nowTime.hour < 10) {
+        return timeDataOne.first.ty5;
+      } else if (nowTime.hour >= 10 && nowTime.hour < 12) {
+        return timeDataOne.first.ty6;
+      } else if (nowTime.hour >= 12 && nowTime.hour < 14) {
+        return timeDataOne.first.ty7;
+      } else if (nowTime.hour >= 14 && nowTime.hour < 16){ // 14 ~ 16 추가
+        return timeDataOne.first.ty8;
+      } else if (nowTime.hour >= 16 && nowTime.hour < 18) {
+        return timeDataOne.first.ty9;
+      } else if (nowTime.hour >= 18 && nowTime.hour < 20) {
+        return timeDataOne.first.ty10;
+      } else if (nowTime.hour >= 20 && nowTime.hour < 22) {
+        return timeDataOne.first.ty11;
+      } else if (nowTime.hour >= 22 && nowTime.hour < 24) {
+        return timeDataOne.first.ty12;
+      }
+      return result;
+    } else {
+      return '갑자13국';
     }
-
-    return result;
   }
 
   List<YukymTimeModel> _getTimeDataOne(String nowDate) {


### PR DESCRIPTION
수정사항

- getTyB에서 조건문에 2 ~ 4와 14 ~ 16 조건이 빠져있음.
- nowDate의 DateFormat이 MM(month)가 아니라 mm(minute)으로 되어 있음.

<br>

- 조건문이 &&가 아닌 || 로 되어있어서 무조건 갑자 1국이 출력되는 오류  
  

```
if (nowTime.hour >= 0 && nowTime.hour < 2) {
  return timeDataOne.first.ty1;
}
```

  
- month만 사용하는 getTyA에서 timeDataOne을 확인할 필요가 없음. getTyB에서 empty 확인하는 것으로 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
	- 날짜 형식이 올바르게 표시되도록 개선했습니다.
- **리팩토링**
	- 시간 및 월별 조건 처리가 개선되어 특정 시간대에 따른 결과 메시지가 더 정확하게 반영됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->