### PR TITLE
250326_02_강선호

### DIFF
--- a/lib/dart_debug_sample.dart
+++ b/lib/dart_debug_sample.dart
@@ -3,7 +3,9 @@ import 'package:intl/intl.dart';
 class YukymController {
 
   // DateTime.parse(_userData.value!.selectDate)
-  String nowDate = DateFormat('yyyy-mm-dd').format(DateTime.now());
+  // 02. nowDate: '2025-54-26'
+  // mm - MM 수정
+  String nowDate = DateFormat('yyyy-MM-dd').format(DateTime.now());
 
   late String nowTime;
 
@@ -14,9 +16,8 @@ class YukymController {
 
     if (timeDataOne.isNotEmpty) {
       nowTime = timeDataOne.first.ty1;
-
       final month = nowDate.substring(5, 7);
-      if (month == '01' || month == '02') {
+      if (month == '01' && month == '02') {
         return '경오1국';
       } else if (month == '03' || month == '04') {
         return '경오2국';
@@ -34,6 +35,8 @@ class YukymController {
       // Handle the case when the list is empty
       return '경오7국';  // Or any other appropriate action
     }
+
+
   }
 
   String getTyB() {
@@ -41,27 +44,61 @@ class YukymController {
     _getTimeDataOne(nowDate);
     String result = timeDataOne.first.ty12;
 
+
+
+    // final nowTime = DateTime.now();
+    // if (nowTime.hour >= 0 || nowTime.hour < 2) {
+    //   return timeDataOne.first.ty1;
+    // } else if (nowTime.hour >= 4 || nowTime.hour < 6) {
+    //   return timeDataOne.first.ty2;
+    // } else if (nowTime.hour >= 6 || nowTime.hour < 8) {
+    //   return timeDataOne.first.ty3;
+    // } else if (nowTime.hour >= 8 || nowTime.hour < 10) {
+    //   return timeDataOne.first.ty4;
+    // } else if (nowTime.hour >= 10 || nowTime.hour < 12) {
+    //   return timeDataOne.first.ty5;
+    // } else if (nowTime.hour >= 12 || nowTime.hour < 14) {
+    //   return timeDataOne.first.ty6;
+    // } else if (nowTime.hour >= 16 || nowTime.hour < 18) {
+    //   return timeDataOne.first.ty7;
+    // } else if (nowTime.hour >= 18 || nowTime.hour < 20) {
+    //   return timeDataOne.first.ty8;
+    // } else if (nowTime.hour >= 20 || nowTime.hour < 22) {
+    //   return timeDataOne.first.ty9;
+    // } else if (nowTime.hour >= 22 || nowTime.hour < 24) {
+    //   return timeDataOne.first.ty10;
+    // }
+    //
+    // return result;
+
+    // 01. 시간 2시 ,14시 누락
+    // nowDate == 2025-50-26 --> nowTime = '갑자 1국'
+    // 03. && 수정시 출력값 변경
     final nowTime = DateTime.now();
-    if (nowTime.hour >= 0 || nowTime.hour < 2) {
+    if (nowTime.hour >= 0 && nowTime.hour < 2) {
       return timeDataOne.first.ty1;
-    } else if (nowTime.hour >= 4 || nowTime.hour < 6) {
+    } else if (nowTime.hour >= 2 && nowTime.hour < 4) {
       return timeDataOne.first.ty2;
-    } else if (nowTime.hour >= 6 || nowTime.hour < 8) {
+    } else if (nowTime.hour >= 4 && nowTime.hour < 6) {
       return timeDataOne.first.ty3;
-    } else if (nowTime.hour >= 8 || nowTime.hour < 10) {
+    } else if (nowTime.hour >= 6 && nowTime.hour < 8) {
       return timeDataOne.first.ty4;
-    } else if (nowTime.hour >= 10 || nowTime.hour < 12) {
+    } else if (nowTime.hour >= 8 && nowTime.hour < 10) {
       return timeDataOne.first.ty5;
-    } else if (nowTime.hour >= 12 || nowTime.hour < 14) {
+    } else if (nowTime.hour >= 10 && nowTime.hour < 12) {
       return timeDataOne.first.ty6;
-    } else if (nowTime.hour >= 16 || nowTime.hour < 18) {
+    } else if (nowTime.hour >= 12 && nowTime.hour < 14) {
       return timeDataOne.first.ty7;
-    } else if (nowTime.hour >= 18 || nowTime.hour < 20) {
+    } else if (nowTime.hour >= 14 && nowTime.hour < 16) {
       return timeDataOne.first.ty8;
-    } else if (nowTime.hour >= 20 || nowTime.hour < 22) {
+    } else if (nowTime.hour >= 16 && nowTime.hour < 18) {
       return timeDataOne.first.ty9;
-    } else if (nowTime.hour >= 22 || nowTime.hour < 24) {
+    } else if (nowTime.hour >= 18 && nowTime.hour < 20) {
       return timeDataOne.first.ty10;
+    } else if (nowTime.hour >= 20 && nowTime.hour < 22) {
+      return timeDataOne.first.ty11;
+    } else if (nowTime.hour >= 22 && nowTime.hour < 24) {
+      return timeDataOne.first.ty12;
     }
 
     return result;


### PR DESCRIPTION
## Fix

---

### 1. getTyB 

- 조건문에 2-4 , 14-16 누락, 코드를 추가했습니다.
- 갑자 1국 오류
`||` 연산자를 사용하면, 0보다 크거나 또는 2보다 작을 때, 란 조건문이기 때문에 `&&` 연산자로 수정

```dart
if (nowTime.hour >= 0 && nowTime.hour < 2) {
      return timeDataOne.first.ty1;
```

---

### 2. nowDate: '2025-54-26'

- DateFormat `MM` - 달
- DateFormat `mm` - 분

- `mm` -> `MM` 으로 수정하였습니다. 

[https://pub.dev/documentation/intl/latest/intl/DateFormat-class.html](url)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
	- 날짜 형식이 개선되어 올바른 날짜 정보가 반영됩니다.
	- 시간대별 결과 출력 로직을 정교하게 다듬어, 특정 시간대에 맞춘 보다 정확한 결과를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->